### PR TITLE
Use service name as source service when dispatching auto events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,17 @@ nameko-eventlog-dispatcher versions, where semantic versioning is used:
 
 Backwards-compatible changes increment the minor version number only.
 
+Version 0.2.0
+-------------
+
+Released 2017-06-*
+
+* Use service name as source service, instead of "all", when dispatching Nameko events automatically.
+
 Version 0.1.0
 -------------
 
-Released 2017-06-16
+Released 2017-06-*
 
 * First release of the library.
 * Add ability to manually dispatch event logs.

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Nameko eventlog dispatcher
     dispatches log data using ``Events`` (Pub-Sub).
 
 
-.. image:: https://travis-ci.org/sohonetlabs/nameko-eventlog-dispatcher.svg?branch=master
+.. image:: https://travis-ci.org/sohonetlabs/nameko-eventlog-dispatcher.png?branch=master
 
 
 Usage
@@ -38,7 +38,8 @@ Include the ``EventLogDispatcher`` dependency in your service class:
 arguments. ``event_data`` must contain JSON serializable data.
 
 Calling ``foo_method`` will dispatch an event from the ``foo`` service
-with ``log_event`` as the event type.
+with ``log_event`` as the event type. However ``foo_event_type`` will be
+the event type stored as part of the event metadata.
 
 Then, any nameko service will be able to handle this event.
 
@@ -72,27 +73,14 @@ Enable auto capture event logs in your nameko configuration file:
 With ``auto_capture`` set to ``true``, a nameko event will be dispatched
 every time an entrypoint is fired:
 
-- The source service for these events will be ``all``.
-- The event type will be ``entrypoint_fired``.
+- They can also be handled by listening ``log_event`` events from the
+  service dispatching them.
+- ``entrypoint_fired`` will be the event type stored as part of the
+  event metadata.
 - Only entrypoints listed in the ``ENTRYPOINT_TYPES_TO_LOG`` class
   attribute will be logged.
 - ``entrypoints_to_exclude`` can be used to provide a list of entrypoint
   method names to exclude when firing events automatically.
-
-Then, any nameko service will be able to handle this kind of events:
-
-.. code-block:: python
-
-    from nameko.events import event_handler
-
-
-    class BazService:
-
-        name = 'baz'
-
-        @event_handler('all', 'entrypoint_fired')
-        def all_entrypoint_fired_event_handler(self, body):
-            """Body will contain the event log data."""
 
 
 Format of the event log data
@@ -106,7 +94,7 @@ This is the format of the event log data:
       "entrypoint_name": "foo_method",
       "service_name": "foo",
       "timestamp": "2017-06-12T13:48:16+00:00",
-      "event_type": "foo_event_type",
+      "event_type": "foo_event_type",  # "entrypoint_fired", ...
       "data": {},
       "call_stack": [
         "standalone_rpc_proxy.call.3f349ea4-ed3e-4a3b-93d0-a36fbf928ecb",

--- a/nameko_eventlog_dispatcher/eventlog_dispatcher.py
+++ b/nameko_eventlog_dispatcher/eventlog_dispatcher.py
@@ -2,11 +2,9 @@ import logging
 from copy import deepcopy
 from datetime import datetime, timezone
 
-from kombu.common import maybe_declare
-from nameko.amqp import get_connection, verify_amqp_uri
 from nameko.events import EventDispatcher
 from nameko.rpc import Rpc
-from nameko.standalone.events import event_dispatcher, get_event_exchange
+from nameko.standalone.events import event_dispatcher
 from nameko.web.handlers import HttpRequestHandler
 
 
@@ -33,9 +31,6 @@ class EventLogDispatcher(EventDispatcher):
     EVENT_TYPE = 'log_event'
     """Event type used by log events dispatched from the entrypoints."""
 
-    SOURCE_SERVICE = 'all'
-    """Source service name used when auto capturing events."""
-
     ENTRYPOINT_TYPES_TO_LOG = (Rpc, HttpRequestHandler)
     """Sequence of entrypoint types to auto capture event logs from."""
 
@@ -48,9 +43,6 @@ class EventLogDispatcher(EventDispatcher):
             'entrypoints_to_exclude'
         ) or []
 
-        if self.auto_capture and self.SOURCE_SERVICE is not None:
-            self._declare_additional_exchange()
-
     def worker_setup(self, worker_ctx):
         super().worker_setup(worker_ctx)
 
@@ -58,36 +50,24 @@ class EventLogDispatcher(EventDispatcher):
             return
 
         try:
-            self._get_dispatch(
-                worker_ctx, source_service=self.SOURCE_SERVICE
-            )(event_type=self.ENTRYPOINT_FIRED)
+            self._get_dispatch(worker_ctx)(event_type=self.ENTRYPOINT_FIRED)
         except Exception as exc:
             log.error(exc)
 
     def get_dependency(self, worker_ctx):
         return self._get_dispatch(worker_ctx)
 
-    def _get_dispatch(self, worker_ctx, source_service=None):
+    def _get_dispatch(self, worker_ctx):
         headers = self.get_message_headers(worker_ctx)
         kwargs = self.kwargs
         dispatcher = event_dispatcher(self.config, headers=headers, **kwargs)
 
-        if source_service is None:
-            source_service = self.service_name
-
-        body = self._get_base_call_info(worker_ctx)
-
         def dispatch(event_type, event_data=None):
+            body = self._get_base_call_info(worker_ctx)
             body['timestamp'] = _get_formatted_utcnow()
             body['event_type'] = event_type
             body['data'] = event_data or {}
-
-            if event_type == self.ENTRYPOINT_FIRED:
-                disp_event_type = self.ENTRYPOINT_FIRED
-            else:
-                disp_event_type = self.EVENT_TYPE
-
-            dispatcher(source_service, disp_event_type, body)
+            dispatcher(self.service_name, self.EVENT_TYPE, body)
 
         return dispatch
 
@@ -100,13 +80,6 @@ class EventLogDispatcher(EventDispatcher):
             'call_id': worker_ctx.call_id,
             'call_stack': deepcopy(worker_ctx.call_id_stack),
         }
-
-    def _declare_additional_exchange(self):
-        common_exchange = get_event_exchange(self.SOURCE_SERVICE)
-        if common_exchange is not None:
-            verify_amqp_uri(self.amqp_uri)
-            with get_connection(self.amqp_uri) as conn:
-                maybe_declare(common_exchange, conn)
 
     def _should_dispatch(self, entrypoint):
         return (

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(file_path, 'README.rst'), 'r', 'utf-8') as readme_file:
 
 setup(
     name='nameko-eventlog-dispatcher',
-    version='0.1.0',
+    version='0.2.0',
     description=(
         'Nameko dependency provider that dispatches log data using Events '
         '(Pub-Sub).'

--- a/test/interface/test_eventlog_dispatcher.py
+++ b/test/interface/test_eventlog_dispatcher.py
@@ -51,12 +51,8 @@ class TestService:
         else:
             self.eventlog_dispatcher('my_event_type')
 
-    @event_handler('all', 'entrypoint_fired')
-    def entrypoint_fired_event_handler(self, body):
-        return body
-
     @event_handler('test_service', 'log_event')
-    def my_event_type_event_handler(self, body):
+    def log_event_handler(self, body):
         return body
 
 
@@ -70,7 +66,7 @@ class TestDispatchEventsAutomatically:
         container.start()
 
         with entrypoint_waiter(
-            container, 'entrypoint_fired_event_handler', timeout=1
+            container, 'log_event_handler', timeout=1
         ) as result:
             with entrypoint_hook(
                 container, 'rpc_entrypoint'
@@ -101,7 +97,7 @@ class TestDispatchEventsAutomatically:
         container.start()
 
         with entrypoint_waiter(
-            container, 'entrypoint_fired_event_handler', timeout=1
+            container, 'log_event_handler', timeout=1
         ) as result:
             web_session.get('/test')
 
@@ -135,9 +131,7 @@ class TestDoNotDispatchEventsAutomatically:
         container.start()
 
         with pytest.raises(EntrypointWaiterTimeout):
-            with entrypoint_waiter(
-                container, 'entrypoint_fired_event_handler', timeout=1
-            ):
+            with entrypoint_waiter(container, 'log_event_handler', timeout=1):
                 with entrypoint_hook(
                     container, 'rpc_entrypoint'
                 ) as rpc_entrypoint:
@@ -150,9 +144,7 @@ class TestDoNotDispatchEventsAutomatically:
         container.start()
 
         with pytest.raises(EntrypointWaiterTimeout):
-            with entrypoint_waiter(
-                container, 'entrypoint_fired_event_handler', timeout=1
-            ):
+            with entrypoint_waiter(container, 'log_event_handler', timeout=1):
                 with entrypoint_hook(
                     container, 'rpc_entrypoint'
                 ) as rpc_entrypoint:
@@ -165,9 +157,7 @@ class TestDoNotDispatchEventsAutomatically:
         container.start()
 
         with pytest.raises(EntrypointWaiterTimeout):
-            with entrypoint_waiter(
-                container, 'entrypoint_fired_event_handler', timeout=1
-            ):
+            with entrypoint_waiter(container, 'log_event_handler', timeout=1):
                 web_session.get('/test')
 
     @pytest.mark.parametrize('auto_capture', [True, False])
@@ -181,9 +171,7 @@ class TestDoNotDispatchEventsAutomatically:
         container.start()
 
         with pytest.raises(EntrypointWaiterTimeout):
-            with entrypoint_waiter(
-                container, 'entrypoint_fired_event_handler', timeout=1
-            ):
+            with entrypoint_waiter(container, 'log_event_handler', timeout=1):
                 with entrypoint_hook(
                     container, 'dummy_entrypoint'
                 ) as dummy_entrypoint:
@@ -217,9 +205,7 @@ class TestUnexpectedErrors:
         event_dispatcher_mock.side_effect = [Mock(), exception]
 
         with pytest.raises(EntrypointWaiterTimeout):
-            with entrypoint_waiter(
-                container, 'entrypoint_fired_event_handler', timeout=1
-            ):
+            with entrypoint_waiter(container, 'log_event_handler', timeout=1):
                 with entrypoint_hook(
                     container, 'rpc_entrypoint'
                 ) as rpc_entrypoint:
@@ -250,7 +236,7 @@ class TestDispatchEventsMaually:
         container.start()
 
         with entrypoint_waiter(
-            container, 'my_event_type_event_handler', timeout=1
+            container, 'log_event_handler', timeout=1
         ) as result:
             with entrypoint_hook(container, 'log_event_method') as log_event:
                 log_event(event_data)

--- a/test/unit/test_dependency_provider.py
+++ b/test/unit/test_dependency_provider.py
@@ -1,7 +1,6 @@
 from unittest.mock import call, patch
 
 import pytest
-from kombu import Exchange
 
 from nameko_eventlog_dispatcher import EventLogDispatcher
 from nameko_eventlog_dispatcher.eventlog_dispatcher import EventDispatcher
@@ -12,13 +11,6 @@ class TestEventLogDispatcherSetup:
     @pytest.fixture
     def super_setup_mock(self):
         with patch.object(EventDispatcher, 'setup') as m:
-            yield m
-
-    @pytest.fixture
-    def maybe_declare_mock(self):
-        with patch(
-            'nameko_eventlog_dispatcher.eventlog_dispatcher.maybe_declare'
-        ) as m:
             yield m
 
     def test_setup_with_default_params(self, mock_container, super_setup_mock):
@@ -66,22 +58,3 @@ class TestEventLogDispatcherSetup:
         assert dependency_provider.entrypoints_to_exclude == [
             'test_1', 'test_2'
         ]
-
-    def test_setup_declares_exchange_when_set_to_auto_capture(
-        self, mock_container, super_setup_mock, config, maybe_declare_mock
-    ):
-        config['EVENTLOG_DISPATCHER'] = {
-            'auto_capture': True,
-            'entrypoints_to_exclude': ['test_1', 'test_2'],
-        }
-        mock_container.config = config
-        dependency_provider = EventLogDispatcher().bind(
-            mock_container, 'eventlog_dispatcher'
-        )
-
-        dependency_provider.setup()
-
-        exchange = maybe_declare_mock.call_args_list[0][0][0]
-        assert maybe_declare_mock.call_count == 1
-        assert isinstance(exchange, Exchange)
-        assert exchange.name == 'all.events'


### PR DESCRIPTION
Use service name as source service when dispatching Nameko events automatically.

This will introduce some improvements:
* It will be less coupled to the Nameko internals.
* It simplifies the dependency provider.
* All the event log data will be captured per service and using a single event type. Since the `entrypoint_fired` event payload is also treated as event log data, there wasn't a good reason to keep it separate.