### PR TITLE
Add metadata argument to dispatch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Released 2017-06-*
 
 * Use service name as source service, instead of ``all``, when dispatching Nameko events automatically.
 * Add the ability to override the default Nameko ``event_type`` (used for the event logs) in the service config.
-* Add MANIFEST.in
+* Add ``MANIFEST.in``
+* Add a ``metadata`` argument to the ``dispatch`` function to provide extra event metadata.
 
 Version 0.1.0
 -------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
+include CHANGELOG.rst
 include CONTRIBUTORS.txt
 include LICENSE
 include README.rst
 
+global-exclude __pycache__
 global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -32,10 +32,13 @@ Include the ``EventLogDispatcher`` dependency in your service class:
 
         @rpc
         def foo_method(self):
-            self.eventlog_dispatcher('foo_event_type', {'value': 1})
+            self.eventlog_dispatcher(
+              'foo_event_type', {'value': 1}, metadata={'meta': 2}
+            )
 
-``event_type`` and  some ``event_data`` (optional) will be provided as
-arguments. ``event_data`` must contain JSON serializable data.
+``event_type``, ``event_data`` (optional) and ``metadata`` (optional)
+can be provided as arguments. Both ``event_data`` and ``metadata`` must
+be dictionaries and contain JSON serializable data.
 
 Calling ``foo_method`` will dispatch an event from the ``foo`` service
 with ``log_event`` as the event type. However ``foo_event_type`` will be

--- a/nameko_eventlog_dispatcher/eventlog_dispatcher.py
+++ b/nameko_eventlog_dispatcher/eventlog_dispatcher.py
@@ -65,8 +65,9 @@ class EventLogDispatcher(EventDispatcher):
         kwargs = self.kwargs
         dispatcher = event_dispatcher(self.config, headers=headers, **kwargs)
 
-        def dispatch(event_type, event_data=None):
+        def dispatch(event_type, event_data=None, metadata=None):
             body = self._get_base_call_info(worker_ctx)
+            body.update(metadata or {})
             body['timestamp'] = _get_formatted_utcnow()
             body['event_type'] = event_type
             body['data'] = event_data or {}


### PR DESCRIPTION
* Add ``metadata`` argument to the ``dispatch`` function. This provides the ability to pass extra metadata when dispatching an event.
* Improve ``MANIFEST.in``