### PR TITLE
Improve CI logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,17 @@ install:
 
 matrix:
   include:
-    - python: 3.4
-      env: TOX_ENV=py34-test
+    - stage: test
+      python: 3.4
+      env: TOX_ENV=py34
 
-    - python: 3.5
-      env: TOX_ENV=py35-test
+    - stage: test
+      python: 3.5
+      env: TOX_ENV=py35
 
-    - python: 3.6
-      env: TOX_ENV=py36-test
+    - stage: test
+      python: 3.6
+      env: TOX_ENV=py36
 
 script:
   - tox -e $TOX_ENV

--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,15 @@ setup(
     zip_safe=True,
     license='MIT License',
     classifiers=[
-        "Programming Language :: Python",
-        "Operating System :: POSIX",
-        "Operating System :: MacOS :: MacOS X",
+        "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Intended Audience :: Developers",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ setup(
     install_requires=['nameko>=2.11,<3.0'],
     extras_require={
         'dev': [
-            'pytest==3.2.5',
-            'flake8',
-            'coverage',
+            'pytest==4.3.0',
+            'flake8>=3.7.6',
+            'coverage>=4.5.2',
         ],
     },
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup(
     extras_require={
         'dev': [
             'pytest==4.3.0',
-            'flake8>=3.7.6',
-            'coverage>=4.5.2',
+            'flake8',
+            'coverage',
         ],
     },
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,6 @@ skipdist = True
 
 [testenv]
 whitelist_externals = make
-deps =
-    flake8
-    coverage
-    pytest==3.2.5
 commands =
-    make coverage ARGS='-x -vv --disable-pytest-warnings'
+    pip install -U --editable ".[dev]"
+    make coverage ARGS='-x -vv'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = {py34, py35, py36}
-skipdist = True
+skipsdist = True
 
 [testenv]
 whitelist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipdist = True
 
 [testenv]
 whitelist_externals = make
+usedevelop = true
+extras = dev
 commands =
-    pip install -U --editable ".[dev]"
     make coverage ARGS='-x -vv'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34, py35, py36, py37}
+envlist = {py34, py35, py36}
 skipdist = True
 
 [testenv]


### PR DESCRIPTION
* Add Travis test `stage` and amend python Tox env
* Remove Python 3.7 logic until that version is tested by Travis:
  * PyPI 3.7 classifier 
  * py37 element from Tox env list
* Update `dev` dependencies and make Tox use them
* Simplify Tox file and make better use of its settings
* Update PyPI package classifiers