### PR TITLE
Add reStructuredText linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 
 language: python
-python: 3.7
-
-dist: xenial
 
 services: rabbitmq
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
+
 language: python
+python: 3.7
+
+dist: xenial
 
 services: rabbitmq
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,20 +10,27 @@ Backwards-compatible changes increment the minor version number only.
 Version 0.3.0
 -------------
 
-* Updated to support Nameko 2.11 (this breaks compatibilty with older Nameko
-  versions)
+Released 2019-01-28
+
+* Updated to support Nameko 2.11 (**this breaks compatibilty with older
+  Nameko versions**).
 * Drop support for Python 3.3
-* Support Python 3.5, 3.6 and 3.7
+* Support Python 3.5 and 3.6
+* Update ``dev`` requirements.
+
 
 Version 0.2.0
 -------------
 
 Released 2017-06-23
 
-* Use service name as source service, instead of ``all``, when dispatching Nameko events automatically.
-* Add the ability to override the default Nameko ``event_type`` (used for the event logs) in the service config.
+* Use service name as source service, instead of ``all``, when
+  dispatching Nameko events automatically.
+* Add the ability to override the default Nameko ``event_type`` (used
+  for the event logs) in the service config.
 * Add ``MANIFEST.in``
-* Add a ``metadata`` argument to the ``dispatch`` function to provide extra event metadata.
+* Add a ``metadata`` argument to the ``dispatch`` function to provide
+  extra event metadata.
 
 Version 0.1.0
 -------------

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ RABBIT_CTL_URI?=http://guest:guest@localhost:15672
 AMQP_URI?=amqp://guest:guest@localhost:5672
 
 
+rst-lint:
+	rst-lint README.rst
+	rst-lint CHANGELOG.rst
+
 flake8:
 	flake8 nameko_eventlog_dispatcher test
 
@@ -12,7 +16,7 @@ test: flake8
 		--rabbit-ctl-uri $(RABBIT_CTL_URI) \
 		--amqp-uri $(AMQP_URI)
 
-coverage: flake8
+coverage: flake8 rst-lint
 	coverage run --concurrency=eventlet \
 		--source nameko_eventlog_dispatcher \
 		-m pytest test $(ARGS) \

--- a/README.rst
+++ b/README.rst
@@ -164,4 +164,5 @@ document for fixes and enhancements of each version.
 License
 -------
 
-The MIT License. See LICENSE for details.
+The MIT License. See `LICENSE <https://github.com/sohonetlabs/nameko-eventlog-dispatcher/blob/master/LICENSE>`_
+for details.

--- a/README.rst
+++ b/README.rst
@@ -152,3 +152,10 @@ variable.
 
     $ make test RABBIT_CTL_URI=http://guest:guest@dockermachine:15673 AMQP_URI=amqp://guest:guest@dockermachine:5673 ARGS='-x -vv --disable-pytest-warnings'
     $ make coverage RABBIT_CTL_URI=http://guest:guest@dockermachine:15673 AMQP_URI=amqp://guest:guest@dockermachine:5673 ARGS='-x -vv --disable-pytest-warnings'
+
+
+Changelog
+---------
+
+Consult the `CHANGELOG <https://github.com/sohonetlabs/nameko-eventlog-dispatcher/blob/master/CHANGELOG.rst>`_
+document for fixes and enhancements of each version.

--- a/README.rst
+++ b/README.rst
@@ -159,3 +159,9 @@ Changelog
 
 Consult the `CHANGELOG <https://github.com/sohonetlabs/nameko-eventlog-dispatcher/blob/master/CHANGELOG.rst>`_
 document for fixes and enhancements of each version.
+
+
+License
+-------
+
+The MIT License. See LICENSE for details.

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,14 @@ Nameko eventlog dispatcher
     dispatches log data using ``Events`` (Pub-Sub).
 
 
+.. image:: https://img.shields.io/pypi/v/nameko-eventlog-dispatcher.svg
+    :target: https://pypi.org/project/nameko-eventlog-dispatcher/
+
+.. image:: https://img.shields.io/pypi/pyversions/nameko-eventlog-dispatcher.svg
+    :target: https://pypi.org/project/nameko-eventlog-dispatcher/
+
 .. image:: https://travis-ci.org/sohonetlabs/nameko-eventlog-dispatcher.png?branch=master
+    :target: https://travis-ci.org/sohonetlabs/nameko-eventlog-dispatcher
 
 
 Usage

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
             'pytest==4.3.0',
             'flake8',
             'coverage',
+            'restructuredtext-lint',
+            'Pygments',
         ],
     },
     zip_safe=True,


### PR DESCRIPTION
Add a reStructuredText linter to check that all the documentation files are syntactically correct.

Trying to make sure that the reStructuredText `README.rst` file can always be rendered on PyPI.

Changes:
* reStructuredText:
  * Add linter
  * Fix `CHANGELOG.rst` syntax
* Add missing info to the `CHANGELOG.rst` file to make it consistent with previous entries.
* README changes:
  * Add status images
  * Add changelog section
  * Add license section