### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 sudo: false
 
 language: python
+python: 3.7
 
-services: rabbitmq
+dist: xenial
+
+before_install:
+  - make docker-rabbitmq-run
 
 install:
   - pip install tox
@@ -20,6 +24,10 @@ matrix:
     - stage: test
       python: 3.6
       env: TOX_ENV=py36
+
+    - stage: test
+      python: 3.7
+      env: TOX_ENV=py37
 
 script:
   - tox -e $TOX_ENV

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,6 @@ coverage: flake8 rst-lint
 # Docker test containers
 
 docker-rabbitmq-run:
-	docker run -d --name rabbitmq-nameko-eventlog-dispatcher \
+	docker run -d --rm --name rabbitmq-nameko-eventlog-dispatcher \
 		-p 15672:15672 -p 5672:5672 \
 		rabbitmq:$(RABBITMQ_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 RABBIT_CTL_URI?=http://guest:guest@localhost:15672
 AMQP_URI?=amqp://guest:guest@localhost:5672
+RABBITMQ_VERSION?=3.7-management
 
 
 rst-lint:
@@ -24,3 +25,9 @@ coverage: flake8 rst-lint
 		--amqp-uri $(AMQP_URI)
 	coverage report -m --fail-under 100
 
+# Docker test containers
+
+docker-rabbitmq-run:
+	docker run -d --name rabbitmq-nameko-eventlog-dispatcher \
+		-p 15672:15672 -p 5672:5672 \
+		rabbitmq:$(RABBITMQ_VERSION)

--- a/README.rst
+++ b/README.rst
@@ -134,8 +134,24 @@ level attributes in the event log data.
 Tests
 -----
 
-It is assumed that RabbitMQ is up and running on the default URL
-``guest:guest@localhost`` and uses the default ports.
+It is assumed that **RabbitMQ** is up and running on the default URI
+``guest:guest@localhost`` and uses the default ports. There is a
+Makefile target to run a RabbitMQ docker containers locally using the
+default ports and configuration:
+
+.. code-block:: shell
+
+    $ make docker-rabbitmq-run
+
+To run the tests locally:
+
+.. code-block:: shell
+
+    $ # Create/activate a virtual environment
+    $ pip install tox
+    $ tox
+
+There are other Makefile targets to run tests:
 
 .. code-block:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34, py35, py36}
+envlist = {py34, py35, py36, py37}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
* Use Docker to run RabbitMQ in the tests
* Add support for Python 3.7
* Update documentation about testing
* Travis CI:
  * Use Python 3.7
  * Use Ubuntu Xenial