### PR TITLE
Improve nameko compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,19 @@ matrix:
   include:
     - stage: test
       python: 3.4
-      env: TOX_ENV=py34
+      env: TOX_ENV=py34-nameko{2.6, 2.7, 2.8, 2.9, 2.10, 2.11}
 
     - stage: test
       python: 3.5
-      env: TOX_ENV=py35
+      env: TOX_ENV=py35-nameko{2.6, 2.7, 2.8, 2.9, 2.10, 2.11}
 
     - stage: test
       python: 3.6
-      env: TOX_ENV=py36
+      env: TOX_ENV=py36-nameko{2.6, 2.7, 2.8, 2.9, 2.10, 2.11}
 
     - stage: test
       python: 3.7
-      env: TOX_ENV=py37
+      env: TOX_ENV=py37-nameko{2.6, 2.7, 2.8, 2.9, 2.10, 2.11}
 
 script:
   - tox -e $TOX_ENV

--- a/nameko_eventlog_dispatcher/eventlog_dispatcher.py
+++ b/nameko_eventlog_dispatcher/eventlog_dispatcher.py
@@ -52,32 +52,33 @@ class EventLogDispatcher(EventDispatcher):
             return
 
         try:
-            self._get_dispatch(worker_ctx)(event_type=self.ENTRYPOINT_FIRED)
+            dispatcher = self.get_dependency(worker_ctx)
+            dispatcher(event_type=self.ENTRYPOINT_FIRED)
         except Exception as exc:
             log.error(exc)
 
     def get_dependency(self, worker_ctx):
-        return self._get_dispatch(worker_ctx)
+        event_dispatcher = super().get_dependency(worker_ctx)
 
-    def _get_dispatch(self, worker_ctx):
-        headers = self.get_message_headers(worker_ctx)
-
-        def dispatch(event_type, event_data=None, metadata=None):
-            body = self._get_base_call_info(worker_ctx)
-            body.update(metadata or {})
-            body['timestamp'] = _get_formatted_utcnow()
-            body['event_type'] = event_type
-            body['data'] = event_data or {}
-            self.publisher.publish(
-                body,
-                exchange=self.exchange,
-                routing_key=self.event_type,
-                extra_headers=headers
+        def dispatch_with_metadata(event_type, event_data=None, metadata=None):
+            wrapped_event_data = self._wrap_event_data(
+                worker_ctx, event_type, event_data, metadata
             )
 
-        return dispatch
+            event_dispatcher(self.event_type, wrapped_event_data)
 
-    def _get_base_call_info(self, worker_ctx):
+        return dispatch_with_metadata
+
+    def _wrap_event_data(self, worker_ctx, event_type, event_data, metadata):
+        envelope = self._get_envelope(worker_ctx)
+        envelope.update(metadata or {})
+        envelope['timestamp'] = _get_formatted_utcnow()
+        envelope['event_type'] = event_type
+        envelope['data'] = event_data or {}
+
+        return envelope
+
+    def _get_envelope(self, worker_ctx):
         entrypoint = worker_ctx.entrypoint
         return {
             'service_name': worker_ctx.service_name,

--- a/nameko_eventlog_dispatcher/eventlog_dispatcher.py
+++ b/nameko_eventlog_dispatcher/eventlog_dispatcher.py
@@ -60,14 +60,14 @@ class EventLogDispatcher(EventDispatcher):
     def get_dependency(self, worker_ctx):
         event_dispatcher = super().get_dependency(worker_ctx)
 
-        def dispatch_with_metadata(event_type, event_data=None, metadata=None):
+        def dispatch(event_type, event_data=None, metadata=None):
             wrapped_event_data = self._wrap_event_data(
                 worker_ctx, event_type, event_data, metadata
             )
 
             event_dispatcher(self.event_type, wrapped_event_data)
 
-        return dispatch_with_metadata
+        return dispatch
 
     def _wrap_event_data(self, worker_ctx, event_type, event_data, metadata):
         envelope = self._get_envelope(worker_ctx)

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ setup(
     author_email='julio.trigo@sohonet.com',
     url='https://github.com/sohonetlabs/nameko-eventlog-dispatcher',
     packages=find_packages(exclude=['test', 'test.*']),
-    install_requires=['nameko>=2.11,<3.0'],
+    install_requires=['nameko>=2.6,<2.12'],
     extras_require={
         'dev': [
-            'pytest==4.3.0',
+            'pytest<=4.3.0',
             'flake8',
             'coverage',
             'restructuredtext-lint',

--- a/test/interface/test_eventlog_dispatcher.py
+++ b/test/interface/test_eventlog_dispatcher.py
@@ -9,11 +9,11 @@ from nameko.testing.services import (
     entrypoint_hook,
     EntrypointWaiterTimeout,
     entrypoint_waiter,
-    get_extension,
 )
 from nameko.web.handlers import http
 
 from nameko_eventlog_dispatcher import EventLogDispatcher
+from nameko_eventlog_dispatcher.eventlog_dispatcher import EventDispatcher
 
 
 @pytest.fixture
@@ -205,10 +205,10 @@ class TestUnexpectedErrors:
 
         exception = Exception('BOOOM!!')
 
-        dependency = get_extension(container, EventLogDispatcher)
-
-        with patch.object(dependency, 'publisher') as mock_publisher:
-            mock_publisher.publish.side_effect = exception
+        with patch.object(
+            EventDispatcher, 'get_dependency'
+        ) as mock_get_dependency:
+            mock_get_dependency.return_value.side_effect = exception
 
             with pytest.raises(EntrypointWaiterTimeout):
                 with entrypoint_waiter(

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,20 @@
 [tox]
-envlist = {py34, py35, py36, py37}
+envlist = {py34, py35, py36, py37}-nameko{2.6, 2.7, 2.8, 2.9, 2.10, 2.11}
 skipsdist = True
 
 [testenv]
 whitelist_externals = make
 usedevelop = true
 extras = dev
+deps =
+    nameko{2.6,2.7}: pytest<3.3.0
+    nameko{2.6,2.7}: eventlet<0.22.0
+    nameko{2.8,2.9,2.10,2.11}: pytest==4.3.0
+    nameko2.6: nameko>=2.6,<2.7
+    nameko2.7: nameko>=2.7,<2.8
+    nameko2.8: nameko>=2.8,<2.9
+    nameko2.9: nameko>=2.9,<2.10
+    nameko2.10: nameko>=2.10,<2.11
+    nameko2.11: nameko>=2.11,<2.12
 commands =
     make coverage ARGS='-x -vv'

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ extras = dev
 deps =
     nameko{2.6,2.7}: pytest<3.3.0
     nameko{2.6,2.7}: eventlet<0.22.0
-    nameko{2.8,2.9,2.10,2.11}: pytest==4.3.0
     nameko2.6: nameko>=2.6,<2.7
     nameko2.7: nameko>=2.7,<2.8
     nameko2.8: nameko>=2.8,<2.9


### PR DESCRIPTION
Decouple the `EventLogDispatcher` from the internals of `nameko.events.EventDispatcher`. This improves compatibility with older nameko versions and should also reduce the amount of work needed to support future nameko versions.