### PR TITLE
Amend test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pytest
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: python
 python: 3.7
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 RABBIT_CTL_URI?=http://guest:guest@localhost:15672
 AMQP_URI?=amqp://guest:guest@localhost:5672
-RABBITMQ_VERSION?=3.7-management
+RABBITMQ_VERSION?=3.6-management
 
 
 rst-lint:

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,11 @@ test: flake8
 coverage: flake8 rst-lint
 	coverage run --concurrency=eventlet \
 		--source nameko_eventlog_dispatcher \
+		--branch \
 		-m pytest test $(ARGS) \
 		--rabbit-ctl-uri $(RABBIT_CTL_URI) \
 		--amqp-uri $(AMQP_URI)
-	coverage report -m --fail-under 100
+	coverage report --show-missing --fail-under 100
 
 # Docker test containers
 

--- a/README.rst
+++ b/README.rst
@@ -154,10 +154,12 @@ To run the tests locally:
     $ pip install tox
     $ tox
 
-There are other Makefile targets to run tests:
+There are other Makefile targets to run the tests, but extra
+dependencies will have to be installed:
 
 .. code-block:: bash
 
+    $ pip install -U --editable ".[dev]"
     $ make test
     $ make coverage
 
@@ -178,7 +180,7 @@ Nameko support
 
 The following Nameko_ versions are supported:
 
-- ``2.x`` series: 2.6, 2.7, 2.8, 2.9, 2.10, 2.11
+- ``2.x`` series: ``2.6``, ``2.7``, ``2.8``, ``2.9``, ``2.10``, ``2.11``
 
 
 Changelog

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,6 @@ extras = dev
 deps =
     nameko{2.6,2.7}: pytest<3.3.0
     nameko{2.6,2.7,2.8}: eventlet<0.22.0
-    nameko{2.6,2.7,2.8,2.9.2.10}: kombu>=3.0.1,<4
-
     nameko2.6: nameko>=2.6,<2.7
     nameko2.7: nameko>=2.7,<2.8
     nameko2.8: nameko>=2.8,<2.9

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ usedevelop = true
 extras = dev
 deps =
     nameko{2.6,2.7}: pytest<3.3.0
-    nameko{2.6,2.7}: eventlet<0.22.0
+    nameko{2.6,2.7,2.8}: eventlet<0.22.0
+    nameko{2.6,2.7,2.8,2.9.2.10}: kombu>=3.0.1,<4
+
     nameko2.6: nameko>=2.6,<2.7
     nameko2.7: nameko>=2.7,<2.8
     nameko2.8: nameko>=2.8,<2.9


### PR DESCRIPTION
Ensure that Tox can be run cleanly locally:
* Use RabbitMQ 3.6 for testing
* Pin test dependencies for old Nameko versions
* Add `branch` coverage
* Amend `.gitignore`
* `sudo` Travis keyword has been fully deprecated.
* Improve testing section in the documentation