### PR TITLE
Add Nameko 2.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,19 @@ matrix:
   include:
     - stage: test
       python: 3.4
-      env: TOX_ENV="py34-nameko{2.6,2.7,2.8,2.9,2.10,2.11}"
+      env: TOX_ENV="py34-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
     - stage: test
       python: 3.5
-      env: TOX_ENV="py35-nameko{2.6,2.7,2.8,2.9,2.10,2.11}"
+      env: TOX_ENV="py35-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
     - stage: test
       python: 3.6
-      env: TOX_ENV="py36-nameko{2.6,2.7,2.8,2.9,2.10,2.11}"
+      env: TOX_ENV="py36-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
     - stage: test
       python: 3.7
-      env: TOX_ENV="py37-nameko{2.6,2.7,2.8,2.9,2.10,2.11}"
+      env: TOX_ENV="py37-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}"
 
 script:
   - tox -e $TOX_ENV

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,14 +8,23 @@ nameko-eventlog-dispatcher versions, where semantic versioning is used:
 Backwards-compatible changes increment the minor version number only.
 
 
+0.4.1
+-----
+
+Released 2019-03-21
+
+* Add Nameko ``2.12`` support (#16)
+* Ensure that Tox can be run cleanly locally (#15)
+
+
 0.4.0
 -----
 
 Released 2019-03-15
 
 * Add support for Python 3.7 (#12)
-* Add support for older Nameko versions: 2.6, 2.7, 2.8, 2.9, 2.10, 2.11
-  (#13, #14)
+* Add support for older Nameko versions: ``2.6``, ``2.7``, ``2.8``,
+  ``2.9``, ``2.10``, ``2.11`` (#13, #14)
 
 
 0.3.0

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ rst-lint:
 	rst-lint CHANGELOG.rst
 
 flake8:
-	flake8 nameko_eventlog_dispatcher test
+	flake8 nameko_eventlog_dispatcher test setup.py
 
 test: flake8
 	pytest test $(ARGS) \

--- a/README.rst
+++ b/README.rst
@@ -180,7 +180,8 @@ Nameko support
 
 The following Nameko_ versions are supported:
 
-- ``2.x`` series: ``2.6``, ``2.7``, ``2.8``, ``2.9``, ``2.10``, ``2.11``
+- ``2.x`` series: ``2.6``, ``2.7``, ``2.8``, ``2.9``, ``2.10``, ``2.11``,
+  ``2.12``
 
 
 Changelog

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(file_path, 'README.rst'), 'r', 'utf-8') as readme_file:
 
 setup(
     name='nameko-eventlog-dispatcher',
-    version='0.4.0',
+    version='0.4.1',
     description=(
         'Nameko dependency provider that dispatches log data using Events '
         '(Pub-Sub).'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author_email='julio.trigo@sohonet.com',
     url='https://github.com/sohonetlabs/nameko-eventlog-dispatcher',
     packages=find_packages(exclude=['test', 'test.*']),
-    install_requires=['nameko>=2.6,<2.12'],
+    install_requires=['nameko>=2.6'],
     extras_require={
         'dev': [
             'pytest<=4.3.0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34,py35,py36,py37}-nameko{2.6,2.7,2.8,2.9,2.10,2.11}
+envlist = {py34,py35,py36,py37}-nameko{2.6,2.7,2.8,2.9,2.10,2.11,2.12,latest}
 skipsdist = True
 
 [testenv]
@@ -15,5 +15,6 @@ deps =
     nameko2.9: nameko>=2.9,<2.10
     nameko2.10: nameko>=2.10,<2.11
     nameko2.11: nameko>=2.11,<2.12
+    nameko2.12: nameko>=2.12,<2.13
 commands =
     make coverage ARGS='-x -vv'


### PR DESCRIPTION
* Add Nameko `2.12` support
* Make sure the latest Nameko release is tested without the need to explicitly add it
* Include the `setup.py` module in the `flake8` checks
* New versions & release notes